### PR TITLE
Added AWS fixes to loadbalancing document

### DIFF
--- a/documentation/loadbalancing.adoc
+++ b/documentation/loadbalancing.adoc
@@ -40,6 +40,8 @@ We solved this by adding a second "server" keyword and telling it to handle the 
 
 This solved the issue. So, if, for whatever reason, the upstream way does not work directly, just add another server {} part, similar to the azure one, and replace the upstream -> server by the same string you add in server -> server_name.
 
+We also did the same for AWS, because we don't know if AWS does load balancing via URL or via IP internally. Using the URL instead of the IP definitely works.
+
 == Appendix ==
 
 [[nginx.conf]]
@@ -97,7 +99,7 @@ http {
 upstream amos1 {
     ip_hash;
     server azure.<your_domain>;
-    server <awsdomain>;
+    server aws.<your_domain>;
     server <googledomain>;
 
 }
@@ -117,6 +119,15 @@ server {
 
     location / {
         proxy_pass http://<azure_domain>;
+    }
+}
+
+server {
+    listen 80;
+    server_name aws.<your_domain>;
+    
+    location / {
+        proxy_pass http://<awsdomain>;
     }
 }
 ----


### PR DESCRIPTION
AWS (probably) requires access via URL instead of IP as well to do load balancing. Fixed in the document.